### PR TITLE
feat(btpnetwork): add logic for to count number of transaction

### DIFF
--- a/packages/dashboard-api/src/modules/btpnetwork/controller.js
+++ b/packages/dashboard-api/src/modules/btpnetwork/controller.js
@@ -8,16 +8,18 @@ const model = require('./model');
 async function getNetworkInfo(request, response) {
   const assets = await model.getAmountFeeAggregationSCORE();
   const totalNetworks = await model.getTotalNetworks();
-  const totalTransaction = await model.getTotalTransactionAmount();
+  const totalTransactionAmount = await model.getTotalTransactionAmount();
+  const totalTransaction = await model.getTotalTransaction();
   response.status(HttpStatus.OK).json({
     content: {
-      volume: (totalTransaction || 0),
+      volume: totalTransactionAmount,
       fee: {
         cumulativeAmount: 100000, // TODO: total tokens ever had in FeeAggregationSCORE
         currentAmount: 500, // TODO: total amount of tokens valid in FeeAggregationSCORE
         assets,
       },
       totalNetworks,
+      totalTransaction,
     },
   });
 }

--- a/packages/dashboard-api/src/modules/btpnetwork/model.js
+++ b/packages/dashboard-api/src/modules/btpnetwork/model.js
@@ -2,7 +2,7 @@
 
 const { logger } = require('../../common');
 const IconService = require('icon-sdk-js');
-const { countNetwork, sumTransactionAmount } = require('./repository');
+const { countNetwork, sumTransactionAmount, countTransaction } = require('./repository');
 const { HttpProvider } = IconService;
 const { IconBuilder } = IconService;
 const provider = new HttpProvider(process.env.NODE_URL);
@@ -64,8 +64,18 @@ async function getTotalTransactionAmount() {
   }
 }
 
+async function getTotalTransaction() {
+  try {
+    return countTransaction();
+  } catch (err) {
+    logger.error(err, '"getTotalTransaction" failed while getting total transaction');
+    throw new Error('"getTotalTransaction" job failed: ' + err.message);
+  }
+}
+
 module.exports = {
   getAmountFeeAggregationSCORE,
   getTotalNetworks,
   getTotalTransactionAmount,
+  getTotalTransaction,
 };

--- a/packages/dashboard-api/src/modules/btpnetwork/repository.js
+++ b/packages/dashboard-api/src/modules/btpnetwork/repository.js
@@ -6,19 +6,29 @@ async function countNetwork() {
   const {
     rows: [result],
   } = await pgPool.query(`SELECT COUNT(*) FROM ${NETWORK_TBL_NAME}`);
-  return result.count;
+  return result.count || 0;
 }
 
 async function sumTransactionAmount() {
   const {
     rows: [result],
   } = await pgPool.query(
-    `SELECT SUM(value) FROM ${TRANSACTION_TBL_NAME} WHERE ${TRANSACTION_TBL.confirmed} = true`,
+    `SELECT SUM(value) FROM ${TRANSACTION_TBL_NAME} WHERE ${TRANSACTION_TBL.confirmed} = true AND ${TRANSACTION_TBL.deleteAt} = 0`,
   );
-  return result.sum;
+  return result.sum || 0;
+}
+
+async function countTransaction() {
+  const {
+    rows: [result],
+  } = await pgPool.query(
+    `SELECT COUNT(*) FROM ${TRANSACTION_TBL_NAME} WHERE ${TRANSACTION_TBL.confirmed} = true AND ${TRANSACTION_TBL.deleteAt} = 0`,
+  );
+  return result.count || 0;
 }
 
 module.exports = {
   countNetwork,
   sumTransactionAmount,
+  countTransaction,
 };


### PR DESCRIPTION
- [x]  Add logic to count the number of transaction

# How to test

**`GET`** http://localhost:8000/v1/btpnetwork


```js
{
    "content": {
        "volume": 0,
        "fee": {
            "cumulativeAmount": 100000,
            "currentAmount": 500,
            "assets": [
                {
                    "name": "SangDepChai",
                    "value": 100000000000000000
                }
            ]
        },
        "totalNetworks": 0,
        "totalTransactions": 0
    }
}
```

# Ref

https://git.baikal.io/btp-dashboard/pm/-/issues/24