### PR TITLE
feat(btpnetwork): implement logic to get total collective value bonded by Relays

### DIFF
--- a/packages/dashboard-api/src/modules/btpnetwork/controller.js
+++ b/packages/dashboard-api/src/modules/btpnetwork/controller.js
@@ -11,9 +11,11 @@ async function getNetworkInfo(request, response) {
   const totalNetworks = await model.getTotalNetworks();
   const totalTransactionAmount = await model.getTotalTransactionAmount();
   const totalTransactions = await model.getTotalTransaction();
+  const bondedRelays = await model.getBondedVolumeByRelays();
   response.status(HttpStatus.OK).json({
     content: {
       volume: totalTransactionAmount,
+      bondedValue: bondedRelays,
       fee: {
         cumulativeAmount: 100000, // TODO: total tokens ever had in FeeAggregationSCORE
         currentAmount: 500, // TODO: total amount of tokens valid in FeeAggregationSCORE

--- a/packages/dashboard-api/src/modules/btpnetwork/model.js
+++ b/packages/dashboard-api/src/modules/btpnetwork/model.js
@@ -3,6 +3,7 @@
 const { logger } = require('../../common');
 const IconService = require('icon-sdk-js');
 const { countNetwork, sumTransactionAmount, countTransaction } = require('./repository');
+const { getTotalBondedRelays } = require('../relays/repository');
 const { HttpProvider } = IconService;
 const { IconBuilder } = IconService;
 const provider = new HttpProvider(process.env.NODE_URL);
@@ -73,9 +74,19 @@ async function getTotalTransaction() {
   }
 }
 
+async function getBondedVolumeByRelays() {
+  try {
+    return getTotalBondedRelays();
+  } catch (err) {
+    logger.error(err, '"getBondedVolumeByRelays" failed while getting total volume by Relays');
+    throw new Error('"getBondedVolumeByRelays" job failed: ' + err.message);
+  }
+}
+
 module.exports = {
   getAmountFeeAggregationSCORE,
   getTotalNetworks,
   getTotalTransactionAmount,
   getTotalTransaction,
+  getBondedVolumeByRelays,
 };

--- a/packages/dashboard-api/src/modules/relays/repository.js
+++ b/packages/dashboard-api/src/modules/relays/repository.js
@@ -10,7 +10,7 @@ async function countTotalRelay() {
     const { rows } = await pgPool.query(query);
     return Number(rows[0].count);
   } catch (error) {
-    logger.error(`countTotalRelay fails`, { error });
+    logger.error('countTotalRelay fails', { error });
     throw error;
   }
 }
@@ -32,21 +32,44 @@ async function getRelayDetailList() {
           bondedICX: Number(row.bonded_icx),
           serverStatus: Number(row.server_status),
           transferredTransactions: Number(row.total_transferred_tx),
-          failedTransactions: Number(row.total_failed_tx)
+          failedTransactions: Number(row.total_failed_tx),
         });
       }
 
       return relays;
     }
   } catch (error) {
-    logger.error(`getRelayList fails`, { error });
+    logger.error('getRelayList fails', { error });
     throw error;
   }
 
   return [];
 }
 
+async function getTotalBondedRelays() {
+  const query = 'SELECT name, bonded_icx as volume FROM relays';
+
+  try {
+    const { rows } = await pgPool.query(query);
+    if (rows.length > 0) {
+      const bondedRelays = [];
+
+      for (const row of rows) {
+        bondedRelays.push({
+          relayName: row.name,
+          volume: Number(row.volume),
+        });
+      }
+      return bondedRelays;
+    }
+  } catch (err) {
+    logger.error('getTotalBondedRelays fails', { err });
+    throw err;
+  }
+}
+
 module.exports = {
   countTotalRelay,
-  getRelayDetailList
+  getRelayDetailList,
+  getTotalBondedRelays,
 };


### PR DESCRIPTION
- [x]  Add logic to get total collective value bonded by Relays

# How to test

**`GET`** http://localhost:8000/v1/btpnetwork


```js
{
    "content": {
        "volume": 1000,
        "bondedValue": 13450,
        "fee": {
            "cumulativeAmount": 100000,
            "currentAmount": 500,
            "assets": [
                {
                    "name": "SangDepChai",
                    "value": 300000000000000000
                }
            ]
        },
        "totalNetworks": 0,
        "totalTransactions": 1
    }
}
```

# Ref

https://git.baikal.io/btp-dashboard/pm/-/issues/32