### PR TITLE
update total current amount and total all time amount of tokens in FAS

### DIFF
--- a/packages/dashboard-api/src/modules/btpnetwork/controller.js
+++ b/packages/dashboard-api/src/modules/btpnetwork/controller.js
@@ -5,7 +5,7 @@ const model = require('./model');
 
 // curl http://localhost:8000/v1/btpnetwork | jq
 async function getNetworkInfo(request, response) {
-  const tokensFAS = await model.getAmountFeeAggregationSCORE();
+  const currentFeeAssets = await model.getAmountFeeAggregationSCORE();
   const totalNetworks = await model.getTotalNetworks();
   const totalTransactionAmount = await model.getTotalTransactionAmount();
   const totalTransactions = await model.getTotalTransaction();
@@ -18,8 +18,8 @@ async function getNetworkInfo(request, response) {
       bondedValue: bondedRelays,
       fee: {
         cumulativeAmount: allTimeFeeAssets.totalUSD,
-        currentAmount: tokensFAS.totalUSD,
-        assert: tokensFAS.assets,
+        currentAmount: currentFeeAssets.totalUSD,
+        assert: currentFeeAssets.assets,
         allTimeAmount: allTimeFeeAssets.feeAssets
       },
       totalNetworks,


### PR DESCRIPTION
Requirement: 3.1.5 GET /btpnetwork

 - Show the total cumulative amount that the Fee Aggregation SCORE has received in  USD.

 - Show the total current amount of fee in the Fee Aggregation SCORE in USD.
 
```
Response:
{
 fee: {
   cumulativeAmount: 100000,
   currentAmount: 500,
 }
}
```


https://git.baikal.io/btp-dashboard/pm/-/issues/165