### PR TITLE
feat: #159 prevent doing bid actions if none wallet connected

### DIFF
--- a/packages/btp-fe/src/connectors/ICONex/iconService.js
+++ b/packages/btp-fe/src/connectors/ICONex/iconService.js
@@ -11,6 +11,7 @@ const { serialize } = IconUtil;
 import { currentICONexNetwork, ADDRESS_LOCAL_STORAGE, signingActions } from '../constants';
 import { requestSigning } from './events';
 import Request from './utils';
+import store from '../../store';
 
 const httpProvider = new HttpProvider(currentICONexNetwork.endpoint);
 const iconService = new IconService(httpProvider);
@@ -83,6 +84,10 @@ export const transfer = (tx) => {
 export const signTx = (transaction = {}, options = {}) => {
   const { from = loggedInAddress, to, value } = transaction;
   const { method, params, builder } = options;
+
+  if (!store.dispatch.modal.isICONexWalletConnected()) {
+    return;
+  }
 
   const txBuilder = builder || new IcxTransactionBuilder();
 

--- a/packages/btp-fe/src/store/models/modal.js
+++ b/packages/btp-fe/src/store/models/modal.js
@@ -1,3 +1,5 @@
+import { wallets } from 'utils/constants';
+
 const modal = {
   name: 'modal',
   state: {
@@ -28,6 +30,24 @@ const modal = {
         icon: 'xIcon',
         desc: (error && error.message) || error || 'Something went wrong!',
       });
+    },
+    isICONexWalletConnected(_, rootState) {
+      const {
+        account: { wallet },
+      } = rootState;
+
+      if (wallet !== wallets.iconex) {
+        this.openModal({
+          icon: 'exclamationPointIcon',
+          desc: 'You must connect to your ICONex wallet first',
+          button: {
+            text: 'Okay',
+            onClick: () => this.setDisplay(false),
+          },
+        });
+        return false;
+      }
+      return true;
     },
   }),
 


### PR DESCRIPTION
Show the dialog of `You must connect to your ICONex wallet first` when none of ICONex wallet connection,

Affect areas: create new bid and place bid

@luanvuonggia please review