### PR TITLE
fix: #179 should turn back to transaction screen after click continue transfer

### DIFF
--- a/packages/btp-fe/src/components/Input/TokenInput.jsx
+++ b/packages/btp-fe/src/components/Input/TokenInput.jsx
@@ -45,25 +45,18 @@ const StyledTokenInput = styled(Input)`
   text-align: center;
 `;
 
-export const TokenInput = ({
-  initalInputDisplay,
-  isCurrent,
-  value,
-  onBlur = () => {},
-  meta = {},
-  ...props
-}) => {
-  const [showInput, setShowInput] = useState(initalInputDisplay === false ? false : true);
+export const TokenInput = ({ isCurrent, value, onBlur = () => {}, meta = {}, ...props }) => {
+  const [showInput, setShowInput] = useState(true);
   const tokenInputRef = useRef();
   const usdBalance = useTokenToUsd('icx', value);
 
   useEffect(() => {
-    if (isCurrent) tokenInputRef.current.focus();
-  }, [isCurrent]);
+    if (isCurrent) {
+      tokenInputRef.current.focus();
+      setShowInput(true);
+    }
+  }, [isCurrent, setShowInput]);
 
-  const toggleInput = () => {
-    setShowInput(!showInput);
-  };
   return (
     <Wrapper>
       <StyledTokenInput
@@ -73,7 +66,7 @@ export const TokenInput = ({
         type="number"
         onBlur={(e) => {
           onBlur(e);
-          toggleInput();
+          setShowInput(false);
         }}
         ref={tokenInputRef}
       />
@@ -81,7 +74,7 @@ export const TokenInput = ({
       <div
         className={`token-label ${!showInput && 'active'}`}
         onClick={() => {
-          toggleInput();
+          setShowInput(true);
           tokenInputRef.current.focus();
         }}
       >

--- a/packages/btp-fe/src/components/TransferBox/Approval.jsx
+++ b/packages/btp-fe/src/components/TransferBox/Approval.jsx
@@ -115,7 +115,7 @@ const Total = styled.div`
   justify-content: space-between;
 `;
 
-export const Approval = memo(({ setStep, values, sendingInfo, account, form, setWasBack }) => {
+export const Approval = memo(({ setStep, values, sendingInfo, account, form }) => {
   const { recipient, tokenAmount } = values;
   const { token, network } = sendingInfo;
   const { currentNetwork, wallet } = account;
@@ -124,7 +124,6 @@ export const Approval = memo(({ setStep, values, sendingInfo, account, form, set
   useListenForSuccessTransaction(() => {
     setStep(0);
     form.restart();
-    setWasBack(false);
   });
 
   const { openModal } = useDispatch(({ modal: { openModal } }) => ({

--- a/packages/btp-fe/src/components/TransferBox/TransferBox.jsx
+++ b/packages/btp-fe/src/components/TransferBox/TransferBox.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback } from 'react';
 import styled from 'styled-components/macro';
 import { Form } from 'react-final-form';
 
@@ -31,7 +31,6 @@ const Wrapper = styled.div`
 
 export const TransferBox = () => {
   const [step, setStep] = useState(0);
-  const [wasBack, setWasBack] = useState(false);
   const [tokenValue, setTokenValue] = useState('');
   const [sendingInfo, setSendingInfo] = useState({ token: '', network: '' });
 
@@ -45,10 +44,6 @@ export const TransferBox = () => {
   const onSendingInfoChange = (info = {}) => {
     setSendingInfo((sendingInfo) => ({ ...sendingInfo, ...info }));
   };
-
-  useEffect(() => {
-    if (step !== 0) setWasBack(true);
-  }, [step]);
 
   const memoizedSetStep = useCallback((param) => setStep(param), [setStep]);
   const memoizedSetTokenValue = useCallback((param) => setTokenValue(param), [setTokenValue]);
@@ -77,7 +72,6 @@ export const TransferBox = () => {
                   setStep={memoizedSetStep}
                   tokenValue={tokenValue}
                   setTokenValue={memoizedSetTokenValue}
-                  initalInputDisplay={!wasBack}
                   isValidForm={valid}
                   sendingInfo={sendingInfo}
                   account={account}
@@ -90,7 +84,6 @@ export const TransferBox = () => {
                   sendingInfo={sendingInfo}
                   account={account}
                   form={form}
-                  setWasBack={setWasBack}
                 />
               </div>
             </form>


### PR DESCRIPTION
Reset transfer form after transferring successes.

HOW TO TEST:

1. My testing account: 
- Private key: 78fdbf396f22c40198a40f7938afc10ccef857501582c22a3229e98adfd5ff09
- Pw (if any): qwerty!123456

2. Change to `Sejong Testnet`
![image](https://user-images.githubusercontent.com/13731780/125382878-b41da600-e3c0-11eb-993b-560b9a9f1912.png)

3. Send token to any address from https://sejong.tracker.solidwallet.io/addresses

@luanvuonggia please review