### PR TITLE
Feat/#171 get  % of available bid amount change in last 24h

### DIFF
--- a/packages/block-indexer/src/common/constants.js
+++ b/packages/block-indexer/src/common/constants.js
@@ -1,7 +1,7 @@
 const TRANSACTION_STATUS = {
   success: 1,
   failed: -1,
-  pending: 0
+  pending: 0,
 };
 
 const TRANSACTION_TBL_NAME = 'transactions';
@@ -21,9 +21,10 @@ const TRANSACTION_TBL = {
   btpFee: 'btp_fee',
   networkFee: 'network_fee',
   status: 'status',
+  totalVolume: 'total_volume',
   createAt: 'create_at',
   updateAt: 'update_at',
-  deleteAt: 'delete_at'
+  deleteAt: 'delete_at',
 };
 
 const ICX_LOOP_UNIT = 10 ** 18;
@@ -32,5 +33,5 @@ module.exports = {
   TRANSACTION_TBL_NAME,
   TRANSACTION_TBL,
   TRANSACTION_STATUS,
-  ICX_LOOP_UNIT
+  ICX_LOOP_UNIT,
 };

--- a/packages/dashboard-api/scripts/db/migration.sql
+++ b/packages/dashboard-api/scripts/db/migration.sql
@@ -12,3 +12,7 @@ WHERE transfer_fees.id=b.id
 UPDATE transfer_fees SET token_amount_usd=b.token_amount
 FROM (SELECT id, token_amount FROM transfer_fees) AS b
 WHERE transfer_fees.id=b.id
+
+
+ALTER TABLE transactions
+  ADD total_volume numeric(100,6) NOT NULL DEFAULT 0,

--- a/packages/dashboard-api/scripts/db/tables.sql
+++ b/packages/dashboard-api/scripts/db/tables.sql
@@ -165,7 +165,8 @@ CREATE TABLE public.transactions (
     block_time bigint,
     btp_fee numeric(100,100),
     network_fee numeric(100,100),
-    status integer DEFAULT 0
+    status integer DEFAULT 0,
+    total_volume numeric(100,6) NOT NULL DEFAULT 0
 );
 
 

--- a/packages/dashboard-api/src/common/constants.js
+++ b/packages/dashboard-api/src/common/constants.js
@@ -36,6 +36,7 @@ const TRANSACTION_TBL = {
   blockTime: 'block_time',
   btpFee: 'btp_fee',
   networkFee: 'network_fee',
+  totalVolume: 'total_volume',
   createAt: 'create_at',
   updateAt: 'update_at',
   deleteAt: 'delete_at',
@@ -51,5 +52,5 @@ module.exports = {
   CURRENCY_IDs,
   CURRENCIES,
   COINs,
-  ICX_LOOP_UNIT
+  ICX_LOOP_UNIT,
 };

--- a/packages/dashboard-api/src/modules/btpnetwork/controller.js
+++ b/packages/dashboard-api/src/modules/btpnetwork/controller.js
@@ -5,6 +5,11 @@ const model = require('./model');
 
 // curl http://localhost:8000/v1/btpnetwork | jq
 async function getNetworkInfo(request, response) {
+  let last24hChange;
+  if (request.query.availableAmountLast24h == 1) {
+    last24hChange = await model.calculateVolumePercents();
+  }
+
   const currentFeeAssets = await model.getAmountFeeAggregationSCORE();
   const totalNetworks = await model.getTotalNetworks();
   const totalTransactionAmount = await model.getTotalTransactionAmount();
@@ -16,17 +21,18 @@ async function getNetworkInfo(request, response) {
   response.status(HttpStatus.OK).json({
     content: {
       volume: totalTransactionAmount,
+      last24hChange,
       bondedValue: bondedRelays,
       fee: {
         cumulativeAmount: allTimeFeeAssets.totalUSD,
         currentAmount: currentFeeAssets.totalUSD,
         assets: currentFeeAssets.assets,
-        allTimeAmount: allTimeFeeAssets.feeAssets
+        allTimeAmount: allTimeFeeAssets.feeAssets,
       },
       totalNetworks,
       totalTransactions,
-      minted: mintedNetworks
-    }
+      minted: mintedNetworks,
+    },
   });
 }
 
@@ -42,11 +48,11 @@ async function getPriceConversion(request, response) {
   const priceTokens = await model.getTokensPriceConversion(baseToken, amount, tokensToConvertTo);
 
   response.status(HttpStatus.OK).json({
-    content: priceTokens
+    content: priceTokens,
   });
 }
 
 module.exports = {
   getNetworkInfo,
-  getPriceConversion
+  getPriceConversion,
 };


### PR DESCRIPTION
- [x] Add total_volume to transaction tbl

- [x] Add logic to calculate totalVolume while creating a new transaction

- [x] Implement logic to get the current totalVolume and totalVolume of 24h ago

 - [x] Implement logic to calculate % of volume change in the past 24h
 - [x] Added  Field `"last24hChange": 300,` unit percentage
 
 # How to test 
 
**`GET`** http://localhost:8000/v1/btpnetwork?availableAmountLast24h=1
```js
{
 content": {
    "volume": 2677.28101965942,
    "last24hChange": 300,
    "bondedValue": 13450,
    "fee": {
      "cumulativeAmount": null,
      "currentAmount": 152.6976,
      "assert": []
      }
     }
```

# Ref 
https://git.baikal.io/btp-dashboard/pm/-/issues/167

/cc @luanvuonggia @duyphanz 