### PR TITLE
fix/#210 Add loading in overview page

### DIFF
--- a/packages/btp-fe/src/containers/Overview/Overview.jsx
+++ b/packages/btp-fe/src/containers/Overview/Overview.jsx
@@ -1,9 +1,10 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelect } from 'hooks/useRematch';
 import styled from 'styled-components/macro';
 
 import { ChartArea } from './ChartArea';
 import { StatisticArea } from './StatisticArea';
+import { Loader } from 'components/Loader';
 import { media } from 'components/Styles/Media';
 
 const Wrapper = styled.div`
@@ -16,7 +17,14 @@ const Wrapper = styled.div`
   `}
 `;
 
+const LoadingPage = styled.div`
+  display: flex;
+  justify-content: center;
+  padding-top: 24px;
+`;
+
 const Overview = () => {
+  const [loading, setLoading] = useState(true);
   const {
     app: { content = {} },
     networks,
@@ -33,15 +41,27 @@ const Overview = () => {
   );
 
   useEffect(() => {
-    getAppInfo();
-    getNetworks();
+    const fetchingData = async () => {
+      await getAppInfo();
+      await getNetworks();
+      setLoading(false);
+    };
+    fetchingData();
   }, [getAppInfo, getNetworks]);
 
   return (
-    <Wrapper>
-      <ChartArea data={content} />
-      <StatisticArea data={content} networks={networks} />
-    </Wrapper>
+    <>
+      {loading ? (
+        <LoadingPage>
+          <Loader size="20px" borderSize="3px" />
+        </LoadingPage>
+      ) : (
+        <Wrapper>
+          <ChartArea data={content} />
+          <StatisticArea data={content} networks={networks} />
+        </Wrapper>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
I see the API `http://54.251.114.18:8000/v1/btpnetwork?mintLast24h=true&&availableAmountLast24h=1`
take more than 4s, So, If this loading makes the UX worsen, **We can close this MR**.