### PR TITLE
Fix/#303 switch wallet should mark the current wallet

### DIFF
--- a/packages/btp-fe/src/components/Header/Header.jsx
+++ b/packages/btp-fe/src/components/Header/Header.jsx
@@ -159,7 +159,9 @@ const mockWallets = {
 
 const Header = () => {
   const [showModal, setShowModal] = useState(false);
-  const [selectedWallet, setSelectedWallet] = useState(wallets.metamask);
+  const [selectedWallet, setSelectedWallet] = useState(
+    localStorage.getItem(CONNECTED_WALLET_LOCAL_STORAGE) || wallets.metamask,
+  );
   const [loading, setLoading] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
   const [showMenu, setShowMenu] = useState(false);


### PR DESCRIPTION
This PR set the current wallet instead of meta mask wallet as default when switching wallet.