### PR TITLE
feat(relayer): fix bug lacking table name on query

### DIFF
--- a/packages/block-indexer/src/modules/icon-indexer/relay-candidate.js
+++ b/packages/block-indexer/src/modules/icon-indexer/relay-candidate.js
@@ -75,7 +75,7 @@ async function saveRelayer(relayer) {
 async function unregisterRelayer(relayer) {
   try {
     const query = `
-      UPDATE SET
+      UPDATE relay_candidates SET
         unregistered_time = $1,
         updated_time = NOW()
       WHERE


### PR DESCRIPTION
- [x] Add table name to query statement

# How to test
- Run packages/block-indexer 
- remove an relayer from BMC

# Root cause
- [x] Missing table name on the query statement
