### PR TITLE
fix: replace getting tokens from contract with getting from token_info table

### DIFF
--- a/packages/dashboard-api/scripts/test_all.sh
+++ b/packages/dashboard-api/scripts/test_all.sh
@@ -35,6 +35,7 @@ curl $HOST/v1/networks | jq
 curl $HOST/v1/networks/0x00
 
 curl $HOST/v1/networks/0x501 | jq
+curl $HOST/v1/networks/0x58eb1c | jq
 
 # relay-candidates
 

--- a/packages/dashboard-api/src/common/constants.js
+++ b/packages/dashboard-api/src/common/constants.js
@@ -20,6 +20,8 @@ const COINs = {
 
 const TRANSACTION_TBL_NAME = 'transactions';
 const NETWORK_TBL_NAME = 'networks';
+const TOKEN_INFO_TBL_NAME = 'token_info';
+
 
 const TRANSACTION_TBL = {
   id: 'id',
@@ -50,4 +52,5 @@ module.exports = {
   CURRENCIES,
   COINs,
   ICX_LOOP_UNIT,
+  TOKEN_INFO_TBL_NAME
 };

--- a/packages/dashboard-api/src/modules/networks/repository.js
+++ b/packages/dashboard-api/src/modules/networks/repository.js
@@ -1,6 +1,6 @@
 'use strict';
 const { logger } = require('../../common');
-const { pgPool, TRANSACTION_TBL_NAME, NETWORK_TBL_NAME } = require('../../common');
+const { pgPool, TRANSACTION_TBL_NAME, NETWORK_TBL_NAME, TOKEN_INFO_TBL_NAME } = require('../../common');
 
 async function getTokensVolume24h() {
   const at24hAgo = new Date().getTime() * 1000 - 86400000000; // current_time(microsecond) - 24h(microsecond)
@@ -152,6 +152,22 @@ async function getVolumeToken24hByNid(name, networkId) {
   }
 }
 
+async function getTokensbyNetworkId(networkId) {
+  try {
+    const { rows } = await pgPool.query(
+      `SELECT token_name
+      FROM ${TOKEN_INFO_TBL_NAME}
+      WHERE network_id = $1`,
+      [networkId]
+    );
+
+    return rows;
+  } catch (error) {
+    logger.error('getTokensbyNetworkId fails', { error });
+    throw error;
+  }
+}
+
 async function getVolumeTokenAllTimeByNid(name, networkId) {
   try {
     const {
@@ -178,4 +194,5 @@ module.exports = {
   getNetworkById,
   getTotalMintValue,
   getTotalBurnValue,
+  getTokensbyNetworkId
 };


### PR DESCRIPTION
Fix the network detail API by replacing getting token names from the contract with getting from the token_info table

# How to test?
Check the source code again and check the result of this request:
```
http://localhost:8000/v1/networks/0x501
http://localhost:8000/v1/networks/0x58eb1c
```

# issue:
#402

