### PR TITLE
fix: send transaction to slack

### DIFF
--- a/packages/block-indexer/src/modules/transactions/icon.js
+++ b/packages/block-indexer/src/modules/transactions/icon.js
@@ -55,7 +55,7 @@ async function confirmTransferEnd(event, txInfo) {
     logTxHashToSlack(
       transaction.to_address,
       transaction.from_address,
-      transaction.tx_hash,
+      txInfo.txHash,
       transaction.block_time,
       transaction.btp_fee,
       transaction.network_fee,
@@ -252,7 +252,7 @@ async function handleBuyTokenEndEvent(event, txResult) {
     logTxHashToSlack(
       transaction.to_address,
       transaction.from_address,
-      transaction.tx_hash,
+      txResult.txHash,
       transaction.block_time,
       transaction.btp_fee,
       transaction.network_fee,

--- a/packages/block-indexer/src/modules/transactions/web3.js
+++ b/packages/block-indexer/src/modules/transactions/web3.js
@@ -175,7 +175,7 @@ class Web3TransactionHandler {
         logTxHashToSlack(
           updatingTx.to_address,
           updatingTx.from_address,
-          updatingTx.tx_hash,
+          txData.txHash,
           updatingTx.block_time,
           updatingTx.btp_fee,
           updatingTx.network_fee,


### PR DESCRIPTION
Send to slack for transactions related to `handleTransferEndEvent` and `handleBuyTokenEndEvent`